### PR TITLE
Example mirroring functionality

### DIFF
--- a/makefile.mk
+++ b/makefile.mk
@@ -16,7 +16,7 @@ WUT_ENABLE_CPP      := 0
 WUT_DEFAULT_MALLOC  := 1
 
 # Target filename
-TARGET              := swipswapme.mod
+TARGET              := swipswapmirror.mod
 
 # Source directories
 SOURCES             := src/ \

--- a/src/common/c_retain_vars.cpp
+++ b/src/common/c_retain_vars.cpp
@@ -16,7 +16,7 @@
  ****************************************************************************/
 #include "common/c_retain_vars.h"
 
-uint8_t gSwap __attribute__((section(".data"))) = 0;
+uint8_t gSwap __attribute__((section(".data"))) = G_SWAP_NORMAL;
 uint8_t gCallbackCooldown __attribute__((section(".data"))) = 0;
 uint8_t gAppStatus __attribute__((section(".data"))) = 0;
 uint32_t gButtonCombo __attribute__((section(".data"))) = 0;

--- a/src/common/c_retain_vars.h
+++ b/src/common/c_retain_vars.h
@@ -19,6 +19,10 @@
 
 #include "utils/voice_info.h"
 extern uint8_t gSwap;
+#define G_SWAP_NORMAL     0
+#define G_SWAP_SWAPPED    1
+#define G_SWAP_MIRROR_TV  2
+#define G_SWAP_MIRROR_DRC 3
 extern uint8_t gCallbackCooldown;
 extern uint8_t gAppStatus;
 extern uint32_t gButtonCombo;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,10 +31,10 @@
 #include <nsysnet/socket.h>
 #include <utils/logger.h>
 
-WUPS_PLUGIN_NAME("SwipSwapMe");
-WUPS_PLUGIN_DESCRIPTION("Swaps the gamepad and tv screen when pressing a certain button (TV is default)");
+WUPS_PLUGIN_NAME("SwipSwapMirror");
+WUPS_PLUGIN_DESCRIPTION("Fork of SwipSwapMe, Swaps the gamepad and tv screen when pressing a certain button (TV is default)");
 WUPS_PLUGIN_VERSION("v1.0");
-WUPS_PLUGIN_AUTHOR("Maschell");
+WUPS_PLUGIN_AUTHOR("KrispyRice9, original by Maschell");
 WUPS_PLUGIN_LICENSE("GPL");
 
 WUPS_FS_ACCESS()


### PR DESCRIPTION
Here's a fork with mirroring functionality added. The motivation was that my family likes to watch BOTW on our projector, which has significant lag over HDMI. I prefer to play by looking at the gamepad's display. Annoyingly, BOTW doesn't allow mirrored display. Hence this mirror functionality, which cycles between normal, swapped, mirrored TV, and mirrored gamepad.
Also, thanks for your work on your excellent WiiU homebrew code and plugin system. Cheers.