### PR TITLE
Fix TV/DRC audio combine mix

### DIFF
--- a/src/function_patcher.cpp
+++ b/src/function_patcher.cpp
@@ -147,7 +147,7 @@ void DoAudioMagic(int16_t *addr, uint32_t size, bool isDRC, AIInitDMAfn targetFu
                     }
                     addr[i] = (int16_t) val;
                     // Combine right channel of TV and DRC
-                    val = (((int32_t) TVCopy[i] + (int32_t) DRCCopy[i]) >> 1);
+                    val = (((int32_t) TVCopy[i + 1] + (int32_t) DRCCopy[i + 1]) >> 1);
                     if (val > 0x7FFF) {
                         val = 0x7FFF;
                     } else if (val < -0x8000) {


### PR DESCRIPTION
The "Combine TV and GamePad sound" mode wasn't grabbing the correct sample offset for the R channel, instead making the combined sound all L channel (essentially mono).