### PR TITLE
Weight parameter to balance TV and DRC audio when combining them

### DIFF
--- a/src/function_patcher.cpp
+++ b/src/function_patcher.cpp
@@ -138,8 +138,9 @@ void DoAudioMagic(int16_t *addr, uint32_t size, bool isDRC, AIInitDMAfn targetFu
             }
             if (gCurAudioMode == AUDIO_MODE_COMBINE) {
                 for (uint32_t i = 0; i < 0x120; i += 2) {
+                    const float tvWeight = 0.9f;
                     // Combine left channel of TV and DRC
-                    auto val = (((int32_t) sTVCopy[i] + (int32_t) sDRCCopy[i]) >> 1);
+                    auto val = (((int32_t) sTVCopy[i]) * tvWeight + ((int32_t) sDRCCopy[i]) * (1.0f - tvWeight)) >> 1;
                     if (val > 0x7FFF) {
                         val = 0x7FFF;
                     } else if (val < -0x8000) {
@@ -147,7 +148,7 @@ void DoAudioMagic(int16_t *addr, uint32_t size, bool isDRC, AIInitDMAfn targetFu
                     }
                     addr[i] = (int16_t) val;
                     // Combine right channel of TV and DRC
-                    val = (((int32_t) sTVCopy[i + 1] + (int32_t) sDRCCopy[i + 1]) >> 1);
+                    val = (((int32_t) sTVCopy[i + 1]) * tvWeight + ((int32_t) sDRCCopy[i + 1]) * (1.0f - tvWeight)) >> 1;
                     if (val > 0x7FFF) {
                         val = 0x7FFF;
                     } else if (val < -0x8000) {

--- a/src/function_patcher.cpp
+++ b/src/function_patcher.cpp
@@ -138,9 +138,9 @@ void DoAudioMagic(int16_t *addr, uint32_t size, bool isDRC, AIInitDMAfn targetFu
             }
             if (gCurAudioMode == AUDIO_MODE_COMBINE) {
                 for (uint32_t i = 0; i < 0x120; i += 2) {
-                    const float tvWeight = 0.9f;
+                    const float tvWeight = (tvWeightRatio + 10) / 20.0f;
                     // Combine left channel of TV and DRC
-                    auto val = (((int32_t) sTVCopy[i]) * tvWeight + ((int32_t) sDRCCopy[i]) * (1.0f - tvWeight)) >> 1;
+                    auto val = (int32_t) (((int32_t) sTVCopy[i]) * tvWeight + ((int32_t) sDRCCopy[i]) * (1.0f - tvWeight)) >> 1;
                     if (val > 0x7FFF) {
                         val = 0x7FFF;
                     } else if (val < -0x8000) {
@@ -148,7 +148,7 @@ void DoAudioMagic(int16_t *addr, uint32_t size, bool isDRC, AIInitDMAfn targetFu
                     }
                     addr[i] = (int16_t) val;
                     // Combine right channel of TV and DRC
-                    val = (((int32_t) sTVCopy[i + 1]) * tvWeight + ((int32_t) sDRCCopy[i + 1]) * (1.0f - tvWeight)) >> 1;
+                    val = (int32_t) (((int32_t) sTVCopy[i + 1]) * tvWeight + ((int32_t) sDRCCopy[i + 1]) * (1.0f - tvWeight)) >> 1;
                     if (val > 0x7FFF) {
                         val = 0x7FFF;
                     } else if (val < -0x8000) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -318,6 +318,9 @@ INITIALIZE_PLUGIN() {
     if ((err = WUPSStorageAPI::GetOrStoreDefault(AUDIO_MODE_CONFIG_STRING, gCurAudioMode, DEFAULT_AUDIO_MODE_CONFIG_VALUE)) != WUPS_STORAGE_ERROR_SUCCESS) {
         DEBUG_FUNCTION_LINE_ERR("Failed to get or create item \"%s\": %s (%d)", AUDIO_MODE_CONFIG_STRING, WUPSStorageAPI_GetStatusStr(err), err);
     }
+    if ((err = WUPSStorageAPI::GetOrStoreDefault(TV_AUDIO_WEIGHT_CONFIG_STRING, tvWeightRatio, DEFAULT_TV_AUDIO_WEIGHT_CONFIG_VALUE)) != WUPS_STORAGE_ERROR_SUCCESS) {
+        DEBUG_FUNCTION_LINE_ERR("Failed to get or create item \"%s\": %s (%d)", TV_AUDIO_WEIGHT_CONFIG_STRING, WUPSStorageAPI_GetStatusStr(err), err);
+    }
 
     if ((err = WUPSStorageAPI::SaveStorage()) != WUPS_STORAGE_ERROR_SUCCESS) {
         DEBUG_FUNCTION_LINE_ERR("Failed to save storage: %s (%d)", WUPSStorageAPI_GetStatusStr(err), err);
@@ -372,6 +375,10 @@ ON_APPLICATION_START() {
 ON_APPLICATION_REQUESTS_EXIT() {
     if (sAudioModeAtStart != gCurAudioMode || sScreenModeAtStart != gCurScreenMode) {
         WUPSStorageError err;
+        if ((err = WUPSStorageAPI::Store(TV_AUDIO_WEIGHT_CONFIG_STRING, tvWeightRatio)) != WUPS_STORAGE_ERROR_SUCCESS) {
+            DEBUG_FUNCTION_LINE_ERR("Failed to store TV audio weight to storage: %s (%d)", WUPSStorageAPI_GetStatusStr(err), err);
+        }
+
         if ((err = WUPSStorageAPI::Store(AUDIO_MODE_CONFIG_STRING, gCurAudioMode)) != WUPS_STORAGE_ERROR_SUCCESS) {
             DEBUG_FUNCTION_LINE_ERR("Failed to store audio mode to storage: %s (%d)", WUPSStorageAPI_GetStatusStr(err), err);
         }

--- a/src/retain_vars.cpp
+++ b/src/retain_vars.cpp
@@ -17,5 +17,6 @@ bool gShowNotifications                                    = DEFAULT_ENABLE_NOTI
 
 SwipSwapScreenMode gCurScreenMode = DEFAULT_SCREEN_MODE_CONFIG_VALUE;
 SwipSwapAudioMode gCurAudioMode   = DEFAULT_AUDIO_MODE_CONFIG_VALUE;
+int32_t tvWeightRatio             = DEFAULT_TV_AUDIO_WEIGHT_CONFIG_VALUE;
 
 bool gNotificationModuleInitDone = true;

--- a/src/retain_vars.hpp
+++ b/src/retain_vars.hpp
@@ -37,3 +37,4 @@ extern bool gNotificationModuleInitDone;
 
 extern SwipSwapScreenMode gCurScreenMode;
 extern SwipSwapAudioMode gCurAudioMode;
+extern int32_t tvWeightRatio;

--- a/src/utils/config.cpp
+++ b/src/utils/config.cpp
@@ -5,6 +5,7 @@
 
 #include <wups/config/WUPSConfigItemBoolean.h>
 #include <wups/config/WUPSConfigItemButtonCombo.h>
+#include <wups/config/WUPSConfigItemIntegerRange.h>
 #include <wups/config/WUPSConfigItemMultipleValues.h>
 #include <wups/storage.h>
 
@@ -82,6 +83,26 @@ static void multiItemChanged(ConfigItemMultipleValues *item, uint32_t newValue) 
     }
 }
 
+void integerRangeItemChanged(ConfigItemIntegerRange *item, int newValue) {
+    if (!item || !item->identifier) {
+        DEBUG_FUNCTION_LINE_WARN("Invalid item or identifier in integer rangeitem callback");
+        return;
+    }
+    DEBUG_FUNCTION_LINE_VERBOSE("New value in %s changed: %d", item->identifier, newValue);
+
+    if (std::string_view(TV_AUDIO_WEIGHT_CONFIG_STRING) == item->identifier) {
+        tvWeightRatio = newValue;
+    } else {
+        DEBUG_FUNCTION_LINE_WARN("Unexpected integer range item: %s", item->identifier);
+        return;
+    }
+
+    WUPSStorageError err;
+    if ((err = WUPSStorageAPI::Store(item->identifier, newValue)) != WUPS_STORAGE_ERROR_SUCCESS) {
+        DEBUG_FUNCTION_LINE_WARN("Failed to store value %d to storage item \"%s\": %s (%d)", newValue, item->identifier, WUPSStorageAPI_GetStatusStr(err), err);
+    }
+}
+
 WUPSConfigAPICallbackStatus ConfigMenuOpenedCallback(WUPSConfigCategoryHandle rootHandle) {
     try {
         WUPSConfigCategory root = WUPSConfigCategory(rootHandle);
@@ -120,6 +141,12 @@ WUPSConfigAPICallbackStatus ConfigMenuOpenedCallback(WUPSConfigCategoryHandle ro
                                                                DEFAULT_AUDIO_MODE_CONFIG_VALUE, gCurAudioMode,
                                                                audioModeMap,
                                                                &multiItemChanged));
+
+        root.add(WUPSConfigItemIntegerRange::Create(TV_AUDIO_WEIGHT_CONFIG_STRING,
+                                                    "TV/GamePad mix when combining audio [-10, 10]:",
+                                                    DEFAULT_TV_AUDIO_WEIGHT_CONFIG_VALUE, tvWeightRatio,
+                                                    -10, 10,
+                                                    &integerRangeItemChanged));
 
         auto buttonCombos = WUPSConfigCategory::Create("Button Combos");
 

--- a/src/utils/config.h
+++ b/src/utils/config.h
@@ -14,6 +14,7 @@
 
 #define DEFAULT_SCREEN_MODE_CONFIG_VALUE                    SCREEN_MODE_NONE
 #define DEFAULT_AUDIO_MODE_CONFIG_VALUE                     AUDIO_MODE_MATCH_SCREEN
+#define DEFAULT_TV_AUDIO_WEIGHT_CONFIG_VALUE                0
 
 #define ENABLED_CONFIG_STRING                               "enabled"
 #define SWAP_SCREENS_CONFIG_STRING_DEPRECATED               "swapScreens"
@@ -29,6 +30,7 @@
 #define CHANGE_SCREEN_BUTTON_COMBO_CONFIG_STRING            "screenChangeButtonComboNew"
 #define CHANGE_AUDIO_BUTTON_COMBO_CONFIG_STRING             "audioButtonComboNew"
 #define AUDIO_MODE_CONFIG_STRING                            "audioMode"
+#define TV_AUDIO_WEIGHT_CONFIG_STRING                       "tvAudioWeight"
 
 
 WUPSConfigAPICallbackStatus ConfigMenuOpenedCallback(WUPSConfigCategoryHandle rootHandle);


### PR DESCRIPTION
I've added a parameter that allows to balance the audio coming from TV and the DRC when using the "Combine TV and GamePad audio" option.
This allows setting a different volume balance (i.e. 70% TV to 30% GamePad).

The weight value is configurable in the settings. It's an integer with range [-10, 10], where -10 is 0% TV to 100% GamePad and 10 is 100% TV and 0% GamePad.

That value gets mapped a float in range [0, 1] and used to affect the volume of the audio streams when `gCurAudioMode == AUDIO_MODE_COMBINE`.

Feel free to suggest further edits or ask for explanations.